### PR TITLE
Create script to scrape only one file from each directory

### DIFF
--- a/scripts/onefile_scraper
+++ b/scripts/onefile_scraper
@@ -9,10 +9,13 @@ do
 	echo $(dirname $filename) >> directory_list
 done
 
+# Deduplicate list of directories
 sort directory_list | uniq >> list_sorted
 
+# Use IFS= to separate by newlines only, not spaces or other escape characters
 while IFS= read -r line
 do
+	# Use -quit to stop the find command after first file is scraped
 	find $line -name "*.dcm" -exec python ../dicom_attribute_scraper/attribute_scraper.py '{}' -o "dir_temp/scraped_dcm_$var" \; -quit
 	var=$((var+1))
 done < list_sorted

--- a/scripts/onefile_scraper
+++ b/scripts/onefile_scraper
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+var=0
+
+mkdir dir_temp
+
+find $1 -name "*.dcm" | while read filename
+do
+	echo $(dirname $filename) >> directory_list
+done
+
+sort directory_list | uniq >> list_sorted
+
+while IFS= read -r line
+do
+	find $line -name "*.dcm" -exec python ../dicom_attribute_scraper/attribute_scraper.py '{}' -o "dir_temp/scraped_dcm_$var" \; -quit
+	var=$((var+1))
+done < list_sorted
+
+find dir_temp -name "scraped_dcm_*" -exec python ../dicom_attribute_scraper/aggregator.py '{}' \+
+
+rm directory_list
+rm list_sorted
+rm -r dir_temp


### PR DESCRIPTION
This script finds all the subdirectories that contain `.dcm` files and only scrapes one from each of them. This effort is to reduce the time taken for the script to produce usable results. 